### PR TITLE
fix wrong instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@ tested with Notepad++ v8.4.7 (64-bit)
 
 ## Syntax-Highlighting
 - Download `userDefineLang_AHK.xml` (as raw)
-- Save it to the right location:
-  - 32-Bit `(C:\Program Files (x86)\Notepad++\)`
-  - 64-Bit `(C:\Program Files\Notepad++\)`
-  - as User `(%AppData%\Notepad++\)`
-- Start Notepad++ and click on Menu `Language -> User Defined Language -> Define your language...`
-- `Import` your userDefineLang_AHK.xml
+- Open your download folder
+- Start Notepad++ and click on Menu `Language -> User Defined Language -> Open User Defined Language folder...`
+- Move `userDefineLang_AHK.xml` from your download folder to this folder
 - `Restart` Notepad++
 
 * **Default Theme** (


### PR DESCRIPTION
Changed instructions to install syntax highlighting

The instructions to install `userDefineLang_AHK.xml` are wrong. It says to save `userDefineLang_AHK.xml` to the Notepad++ folder in the program folder or appdata folder and then to `Import` it in Notepad++. However, `Import` itself takes care of storing the data from `userDefineLang_AHK.xml`, so `userDefineLang_AHK.xml` should not be saved to the Notepad++ folder. It doesn't hurt, but it doesn't do anything either.

Furthermore, it is advised not to use `Import` because that makes it harder to install a new `userDefineLang_AHK.xml` if there is an update. `Import` always adds an extra User Defined Language and never updates one. And there is this [issue](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8101) when deleting an imported User Defined Language.

It is better to use the alternative way of installing a User Defined Language in Notepadd++, that is to save `userDefineLang_AHK.xml` to  Notepad++'s User Defined Language folder.
